### PR TITLE
Fix documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,7 +27,7 @@ Libraries are dependecies defined inside setup file.
 Using Pip
 ---------
 
-Django is core is not currently inside *PyPE* but in the future you will be able to use:
+Django pyston is not currently inside *PyPE* but in the future you will be able to use:
 
 .. code-block:: console
 


### PR DESCRIPTION
There is a typo in the docs, the project is called "pyston", not "is core".