### PR TITLE
Check allowed methods before request deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ build/config
 # Test generated files #
 ########################
 media/
+
+# Egg #
+######
+django_pyston.egg-info/

--- a/pyston/resource.py
+++ b/pyston/resource.py
@@ -385,16 +385,15 @@ class BaseResource(PermissionsResourceMixin, metaclass=ResourceMetaClass):
 
         fieldset = True
         try:
-            self.request = self._deserialize()
-
             rm = self.request.method.lower()
             meth = getattr(self, rm, None)
 
             if not meth or rm not in self.get_allowed_methods():
                 raise NotAllowedMethodException
-            else:
-                self._check_permission(rm)
-                result = meth()
+
+            self.request = self._deserialize()
+            self._check_permission(rm)
+            result = meth()
         except Exception as ex:
             result = self._get_error_response_from_exception(ex)
             if result is None:


### PR DESCRIPTION
Currently, request is deserialized even when disallowed method is used to query resource. This might end up in HTTP 500 if deserialization fails. I believe, when method is not allowed, request should not be parsed and HTTP 405 should be returned right away.